### PR TITLE
haproxy should not listen on localhost

### DIFF
--- a/servo/haproxy/haproxy_conf.py
+++ b/servo/haproxy/haproxy_conf.py
@@ -20,16 +20,20 @@ import os
 import base64
 import servo
 import servo.config as config
-from servo.lb_policy import AppCookieStickinessPolicy, LBCookieStickinessPolicy, SSLNegotiationPolicy, PublicKeyPolicy, BackendServerAuthenticationPolicy
+from servo.lb_policy import AppCookieStickinessPolicy, LBCookieStickinessPolicy, SSLNegotiationPolicy, \
+    PublicKeyPolicy, BackendServerAuthenticationPolicy
 from servo.mon.log import HttpAccessLog, TcpAccessLog
+
+section_name_prefix = ['global', 'listen', 'defaults', 'frontend', 'backend']
+
 
 class ConfBuilder(object):
     def __init__(self, source, loadbalancer=None):
-        ## read the file contents
+        # read the file contents
         self.loadbalancer = loadbalancer
         self.contents = []
         try:
-            f=open(source, "r")
+            f = open(source, "r")
             self.contents = f.readlines()
             f.close()
         except Exception, err:
@@ -38,16 +42,18 @@ class ConfBuilder(object):
     def build(self, destination=None):
         raise NotImplementedError
 
-    def add(self, protocol, port, instances=[], policies=[], cert=None, comment=None, connection_idle_timeout=None):
+    def add(self, protocol, ips, port, instances=[], policies=[], cert=None, comment=None,
+            connection_idle_timeout=None):
         try:
-            self.add_protocol_port(protocol, port, policies, cert, comment, connection_idle_timeout = connection_idle_timeout )
+            self.add_protocol_port(protocol, ips, port, policies, cert, comment,
+                                   connection_idle_timeout=connection_idle_timeout)
             for instance in instances:
                 self.add_backend(port, instance, policies)
         except Exception, err:
             servo.log.error('failed to add protocol-port: %s' % err)
         return self
 
-    def add_protocol_port(self, protocol, port, policies, cert=None, comment=None, connection_idle_timeout=None):
+    def add_protocol_port(self, ip, protocol, port, policies, cert=None, comment=None, connection_idle_timeout=None):
         raise NotImplementedError
   
     def remove_protocol_port(self, port):
@@ -59,18 +65,18 @@ class ConfBuilder(object):
     def verify(self, listeners):
         raise NotImplementedError
 
-section_name_prefix = ['global','listen','defaults','frontend','backend']
+
 class ConfBuilderHaproxy(ConfBuilder):
     def __init__(self, source, loadbalancer=None):
         ConfBuilder.__init__(self, source, loadbalancer)
-        self.__content_map = {} # key=section name(e.g, frontend), value: lines in the section
-        cur_key=None
+        self.__content_map = {}  # key=section name(e.g, frontend), value: lines in the section
+        cur_key = None
         for line in self.contents:
-            key=line.strip('\n ').split(' ')[0]
+            key = line.strip('\n ').split(' ')[0]
             if key in section_name_prefix:
                 cur_key = line.strip('\n ')
                 self.__content_map[cur_key] = []
-            elif cur_key is not None and len(line.strip('\n '))>0:
+            elif cur_key is not None and len(line.strip('\n ')) > 0:
                 self.__content_map[cur_key].append(line.strip('\n '))
 
     def build(self, destination=None):
@@ -88,16 +94,16 @@ class ConfBuilderHaproxy(ConfBuilder):
                 lines.extend(['  %s\n' % line for line in section_contents])  
                 lines.append('\n')
 
-        frontends = [ key for key in self.__content_map.iterkeys() if key.startswith('frontend') ]
-        backends =  [ key for key in self.__content_map.iterkeys() if key.startswith('backend') ]
+        frontends = [key for key in self.__content_map.iterkeys() if key.startswith('frontend')]
+        backends = [key for key in self.__content_map.iterkeys() if key.startswith('backend')]
         for fe in frontends:
             lines.append('%s\n' % fe)
-            lines.extend(['  %s\n' % line for line in self.__content_map[fe] ])
+            lines.extend(['  %s\n' % line for line in self.__content_map[fe]])
             lines.append('\n')
         
         for be in backends:
             lines.append('%s\n' % be)
-            lines.extend(['  %s\n' % line for line in self.__content_map[be] ])
+            lines.extend(['  %s\n' % line for line in self.__content_map[be]])
             lines.append('\n')
      
         if destination is None:
@@ -105,13 +111,13 @@ class ConfBuilderHaproxy(ConfBuilder):
         try:
             if os.path.exists(destination):
                 os.unlink(destination)
-            f=open(destination, "w")
+            f = open(destination, "w")
             for line in lines:
                 f.write(line)
             f.close()
         except Exception, err:
             raise Exception(err)
-             #  TODO: LOG ERROR
+            #  TODO: LOG ERROR
 
     @staticmethod
     def parse_key_value(line, delimiter=' '):
@@ -139,24 +145,25 @@ class ConfBuilderHaproxy(ConfBuilder):
                     break
         return backend_name
 
-    def add_protocol_port(self, protocol='tcp', port=80, policies=[], cert=None, comment=None, connection_idle_timeout=None):
+    def add_protocol_port(self, protocol='tcp', ips=['0.0.0.0'], port=80, policies=[], cert=None, comment=None,
+                          connection_idle_timeout=None):
         '''
             add new protocol/port to the config file. if there's existing one, pass
         '''
-        if not ( protocol == 'http' or protocol == 'tcp' or protocol == 'https' or protocol == 'ssl'):
+        if not (protocol == 'http' or protocol == 'tcp' or protocol == 'https' or protocol == 'ssl'):
             raise Exception('unknown protocol')
 
         # make sure no other frontend listen on the port
         for key in self.__content_map.iterkeys():
             key = key.strip(' ')
-            if key.startswith('frontend') and key.endswith('-%s'%port):
+            if key.startswith('frontend') and key.endswith('-%s' % port):
                 raise Exception('the port is found')
             
-        section_name = 'frontend %s-%s' % (protocol,port)
-        if not section_name in self.__content_map.iterkeys():
-            self.__content_map[section_name]= [] 
+        section_name = 'frontend %s-%s' % (protocol, port)
+        if section_name not in self.__content_map.iterkeys():
+            self.__content_map[section_name] = []
             if comment is not None:
-                self.__content_map[section_name].append('# %s'%comment)
+                self.__content_map[section_name].append('# %s' % comment)
             if protocol == 'https':
                 self.__content_map[section_name].append('mode http')
             elif protocol == 'ssl':
@@ -170,21 +177,25 @@ class ConfBuilderHaproxy(ConfBuilder):
             if protocol == 'https' or protocol == 'ssl':
                 # haproxy always disables sslv2
                 sslv_setting = ''
-                if ConfBuilderHaproxy.ssl_v3(policies) == False:
+                if ConfBuilderHaproxy.ssl_v3(policies) is False:
                     sslv_setting = '%s no-sslv3' % sslv_setting
-                if ConfBuilderHaproxy.tls_v1(policies) == False:
+                if ConfBuilderHaproxy.tls_v1(policies) is False:
                     sslv_setting = '%s no-tlsv10' % sslv_setting 
-                if ConfBuilderHaproxy.tls_v11(policies) == False:
+                if ConfBuilderHaproxy.tls_v11(policies) is False:
                     sslv_setting = '%s no-tlsv11' % sslv_setting
-                if ConfBuilderHaproxy.tls_v12(policies) == False:
+                if ConfBuilderHaproxy.tls_v12(policies) is False:
                     sslv_setting = '%s no-tlsv12' % sslv_setting
                 cipher_str = ConfBuilderHaproxy.cipher_string(policies)
-                if cipher_str:
-                    self.__content_map[section_name].append('bind 0.0.0.0:%s ssl crt %s %s ciphers %s' % (port, cert, sslv_setting, cipher_str))
-                else:
-                    self.__content_map[section_name].append('bind 0.0.0.0:%s ssl crt %s %s' % (port, cert, sslv_setting))
+                for ip in ips:
+                    if cipher_str:
+                        self.__content_map[section_name].append('bind %s:%s ssl crt %s %s ciphers %s' %
+                                                                (ip, port, cert, sslv_setting, cipher_str))
+                    else:
+                        self.__content_map[section_name].append('bind %s:%s ssl crt %s %s' %
+                                                                (ip, port, cert, sslv_setting))
             else: 
-                self.__content_map[section_name].append('bind 0.0.0.0:%s' % port)
+                for ip in ips:
+                    self.__content_map[section_name].append('bind %s:%s' % (ip, port))
 
             if connection_idle_timeout:
                 self.__content_map[section_name].append('timeout client %ss' % connection_idle_timeout)
@@ -213,20 +224,23 @@ class ConfBuilderHaproxy(ConfBuilder):
             cookie_name = ConfBuilderHaproxy.get_app_cookie_name(policies)
             cookie_expire = ConfBuilderHaproxy.get_lb_cookie_period(policies)
             
-            if ( protocol == 'http' or protocol == 'https' ) and cookie_expire:
+            if (protocol == 'http' or protocol == 'https') and cookie_expire:
                 try:
                     cookie_expire = int(cookie_expire)
                     cache_control_header = '\n  http-response set-header Cache-control no-cache=\"set-cookie\"'
-                    backend_attribute = '%s%s\n  cookie AWSELB insert indirect maxidle %ds maxlife %ds' % (backend_attribute, cache_control_header, cookie_expire, cookie_expire) 
+                    backend_attribute = '%s%s\n  cookie AWSELB insert indirect maxidle %ds maxlife %ds' % \
+                                        (backend_attribute, cache_control_header, cookie_expire, cookie_expire)
                 except exceptions.ValueError:
                     servo.log.error('failed to set cookie expiration: value is not a number type')
-            elif ( protocol == 'http' or protocol == 'https' ) and cookie_name:
-                backend_attribute = '%s\n  appsession %s len %d timeout %dm' % (backend_attribute, cookie_name, config.appcookie_length(), config.appcookie_timeout())
+            elif (protocol == 'http' or protocol == 'https') and cookie_name:
+                backend_attribute = '%s\n  appsession %s len %d timeout %dm' % (backend_attribute, cookie_name,
+                                                                                config.appcookie_length(),
+                                                                                config.appcookie_timeout())
           
             # create the empty backend section
             self.__content_map['backend %s' % def_backend] = [backend_attribute]
         else:
-            pass # do nothing
+            pass  # do nothing
 
         return self
 
@@ -241,10 +255,11 @@ class ConfBuilderHaproxy(ConfBuilder):
         for p in policies:
             if type(p) is BackendServerAuthenticationPolicy:
                 for pub_key_policy in p.public_key_policy_names():
-                    if pubkey_map.has_key(pub_key_policy):
+                    if pub_key_policy in pubkey_map:
                         pubkeys_mapped.append(pubkey_map[pub_key_policy])
 
         return pubkeys_mapped
+
     @staticmethod
     def cipher_string(policies):
         if not policies or len(policies) <= 0:
@@ -278,7 +293,7 @@ class ConfBuilderHaproxy(ConfBuilder):
     @staticmethod
     def check_ssl_ver(policies, func):
         if not policies:
-             return None
+            return None
         for p in policies:
             if type(p) is SSLNegotiationPolicy:
                 return getattr(p, func)()
@@ -287,7 +302,7 @@ class ConfBuilderHaproxy(ConfBuilder):
     @staticmethod
     def get_app_cookie_name(policies):
         if not policies:
-             return None
+            return None
         for p in policies:
             if type(p) is AppCookieStickinessPolicy:
                 return p.cookie_name()
@@ -296,7 +311,7 @@ class ConfBuilderHaproxy(ConfBuilder):
     @staticmethod 
     def get_lb_cookie_period(policies):
         if not policies:
-             return None
+            return None
         for p in policies:
             if type(p) is LBCookieStickinessPolicy:
                 return int(p.cookie_expiration_period())
@@ -309,7 +324,7 @@ class ConfBuilderHaproxy(ConfBuilder):
         (section_name, section) = self.find_frontend(port)
         if section_name is None:
             return self
-        #remove the backend
+        # remove the backend
         backend_name = self.find_backend_name(section)
         if backend_name is not None:
             backend = 'backend %s' % backend_name 
@@ -317,12 +332,12 @@ class ConfBuilderHaproxy(ConfBuilder):
                 backend_conf = self.__content_map.pop(backend)
                 del backend_conf[:]
 
-        #remove the frontend
+        # remove the frontend
         frontend_conf = self.__content_map.pop(section_name)
         del frontend_conf[:]
         return self
 
-    #instance = {hostname , port, protocol=None )
+    # instance = {hostname , port, protocol=None )
     def add_backend(self, port, instance, policies):
         (section_name, section) = self.find_frontend(port)
         if section_name is None:
@@ -344,11 +359,12 @@ class ConfBuilderHaproxy(ConfBuilder):
         elif any("appsession " in s for s in backend_conf):
             appcookie_enabled = True
 
-        line = 'server %s %s:%d' % (section_name.replace('frontend','').strip(' '), instance['hostname'], instance['port'])
+        line = 'server %s %s:%d' % \
+               (section_name.replace('frontend', '').strip(' '), instance['hostname'], instance['port'])
         if lbcookie_enabled or appcookie_enabled:
             line = line + ' cookie %s' % ConfBuilderHaproxy.encode_str(instance['hostname'])
      
-        #backend authentication is requested 
+        # backend authentication is requested
         if instance['protocol'] == 'https' or instance['protocol'] == 'ssl':
             pubkeys = ConfBuilderHaproxy.backend_server_pubkeys(policies) 
             if pubkeys and len(pubkeys) > 0:


### PR DESCRIPTION
The load balancer servo now configures haproxy to listen on the private ips of the instance as determined from instance metadata.

There are pep8 changes, most of which can be ignored by reviewing without white space changes shown.

This fixes Corymbia/eucalyptus#22