### PR TITLE
Add botocore dependency for boto 3

### DIFF
--- a/load-balancer-servo.spec
+++ b/load-balancer-servo.spec
@@ -21,6 +21,7 @@ BuildRequires:  systemd
 Requires:       python%{?__python_ver}
 Requires:       python%{?__python_ver}-boto
 Requires:       python%{?__python_ver}-boto3
+Requires:       python%{?__python_ver}-botocore
 Requires:       python%{?__python_ver}-httplib2
 Requires:       haproxy >= 1.5
 Requires:       sudo


### PR DESCRIPTION
From 5.0 we use boto 3 for simple workflow activities. Boto 3 in centos 7 requires:

```
# rpm -q --requires python-boto3
python(abi) = 2.7
python-s3transfer >= 0.1.10
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PartialHardlinkSets) <= 4.0.4-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsXz) <= 5.2-1
```
When run the workflow client fails with an error:
```
Traceback (most recent call last):
  File "/bin/load-balancer-servo-workflow", line 9, in <module>
    load_entry_point('Eucalyptus-Loadbalancer-Servo==1.5.0', 'console_scripts', 'load-balancer-servo-workflow')()
  File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 378, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 2566, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 2260, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
  File "/usr/lib/python2.7/site-packages/servo/workflow/client.py", line 7, in <module>
    import boto3
  File "/usr/lib/python2.7/site-packages/boto3/__init__.py", line 16, in <module>
    from boto3.session import Session
  File "/usr/lib/python2.7/site-packages/boto3/session.py", line 19, in <module>
    import botocore.session
ImportError: No module named botocore.session
```
As `botocore` is also required.

This can be reproduced by installing `python-boto3` and:

```
# python -c "import boto3"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python2.7/site-packages/boto3/__init__.py", line 16, in <module>
    from boto3.session import Session
  File "/usr/lib/python2.7/site-packages/boto3/session.py", line 19, in <module>
    import botocore.session
ImportError: No module named botocore.session
```