### PR TITLE
Fix ambiguous python shebangs

### DIFF
--- a/load-balancer-servo
+++ b/load-balancer-servo
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 #
 # Copyright 2009-2013 Eucalyptus Systems, Inc.
 #

--- a/load-balancer-servo.spec
+++ b/load-balancer-servo.spec
@@ -52,6 +52,8 @@ rm -rf $RPM_BUILD_ROOT
 
 # Install CLI tools
 %{__python} setup.py install -O1 --skip-build --root $RPM_BUILD_ROOT
+sed --in-place '1s/python /python2 /' $RPM_BUILD_ROOT/usr/bin/load-balancer-servo
+sed --in-place '1s/python$/python2/'  $RPM_BUILD_ROOT/usr/bin/load-balancer-servo-workflow
 
 #
 # There is no extension on the installed sudoers file for a reason

--- a/scripts/servo-prep
+++ b/scripts/servo-prep
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 #
 # Copyright 2016 Hewlett Packard Enterprise Development Company LP.
 #


### PR DESCRIPTION
Fix ambiguous python shebangs as these can otherwise cause build failures.

Example packaging guidelines covering python 2 use:
https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_multiple_python_runtimes

Build:  ocd/job/eucalyptus-internal-5-build-random-rpms/57/
QA run: ocd/job/eucalyptus-5-qa-suite/55/